### PR TITLE
export redis.nil via NilReply

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -16,7 +16,7 @@
   branch = "master"
   name = "github.com/alauda/go-redis-client"
   packages = ["."]
-  revision = "a90ea14ebebab48949ac0217104ad7a6b475cfa8"
+  revision = "77d2151d94bc29dc02edf407001fc57ba065bde3"
 
 [[projects]]
   branch = "master"
@@ -393,6 +393,6 @@
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "11edd9da1a8df6d676a9e7fb4d556cda778281507172f351b66739f45d921045"
+  inputs-digest = "6a142e79e6638a850baef3b7825a1ccac530b128f8f258bf54e40cfde12ef8bb"
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/cache/redis.go
+++ b/cache/redis.go
@@ -9,6 +9,9 @@ import (
 	aredis "github.com/alauda/go-redis-client"
 )
 
+// NilReply represent Redis nil reply, .e.g. when key does not exist.
+const NilReply = aredis.RedisNil
+
 type (
 	// RedisCache abstraction used to store a redis connection
 	RedisCache struct {
@@ -101,4 +104,9 @@ func (r *RedisCache) Diagnose() diagnose.ComponentReport {
 // GetAddr will return a string of the addres which is host:port
 func (r RedisOpts) GetAddr() string {
 	return fmt.Sprintf("%s:%d", r.Host, r.Port)
+}
+
+// IsCacheErr will ignore redis.nil for error handler
+func IsCacheErr(err error) bool {
+	return err != nil && err != NilReply
 }

--- a/vendor/github.com/alauda/go-redis-client/client.go
+++ b/vendor/github.com/alauda/go-redis-client/client.go
@@ -8,6 +8,9 @@ import (
 	"github.com/go-redis/redis"
 )
 
+// RedisNil means nil reply, .e.g. when key does not exist.
+const RedisNil = redis.Nil
+
 // Client a struct representing the redis client
 type Client struct {
 	opts      Options


### PR DESCRIPTION
When using blpop, if timeout and there is no value return, go-redis will return a redis.nil error. Export redis.nil so we can use if err!=nil && err!=NilReply to ignore the error.

Need https://github.com/alauda/go-redis-client/pull/3 merge first.
Then need to update the vendor.